### PR TITLE
Set Notice Popup Max Height

### DIFF
--- a/src/views/helpPoints/View_Map/ViewMap.jsx
+++ b/src/views/helpPoints/View_Map/ViewMap.jsx
@@ -24,8 +24,7 @@ const ViewMap = () => {
             zoom={14}
             maxZoom={18}
             scrollWheelZoom={true}
-            className={`bg-white dark:bg-gray-900 relative z-0 threat-map`}
-            style={{ height: '100vh' }}>
+            className={`bg-white dark:bg-gray-900 relative z-0 threat-map h-full`}>
             {/* <Sidebar /> */}
             <MapLayers />
             <TileLayer

--- a/src/views/helpPoints/View_Map/components/popups/NoticePopup.jsx
+++ b/src/views/helpPoints/View_Map/components/popups/NoticePopup.jsx
@@ -16,13 +16,14 @@ const noticeTypes = {
 }
 
 const NoticePopup = (props) => {
+  const maxPopupHeight = useMemo(() => window.innerHeight - document.querySelector("#root header").clientHeight * 2, [window.innerHeight])
   const PopupComponent = useMemo(
     () => (props.type in noticeTypes ? noticeTypes[props.type] : noticeTypes[1]),
     [props.type],
   )
 
   return (
-    <Popup>
+    <Popup maxHeight={maxPopupHeight}>
       <PopupComponent {...props} />
     </Popup>
   )


### PR DESCRIPTION
Bugfix https://trello.com/c/v3Ttd3bk/133-important-mobile-bug-on-map-video-in-comment
(+ some inline-style removed).

Fixed by adding Notice Popup Maximum Height, as a window height minus 2x header height.
A scroll will be added to the Popup if content higher than max. height.

![image](https://user-images.githubusercontent.com/101098165/157362276-638e2c85-7cbc-4bfb-bfa9-9e900379d036.png)


Docs:
https://leafletjs.com/index.html#popup