### PR TITLE
Move axios mock to dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@szhsin/react-menu": "^2.3.1",
         "apexcharts": "^3.31.0",
         "axios": "^0.24.0",
-        "axios-mock-adapter": "^1.20.0",
         "classnames": "^2.3.1",
         "dayjs": "^1.10.7",
         "i18next": "^21.6.12",
@@ -38,7 +37,7 @@
         "react-is": "^17.0.2",
         "react-leaflet": "^3.2.2",
         "react-leaflet-markercluster": "^3.0.0-rc1",
-        "react-phone-input-2": "^2.15.0",
+        "react-phone-input-2": "2.15.0",
         "react-query": "^3.34.0",
         "react-redux": "^7.2.6",
         "react-router": "^6.2.1",
@@ -58,6 +57,7 @@
       "devDependencies": {
         "@vitejs/plugin-react-refresh": "^1.3.1",
         "autoprefixer": "^10.3.3",
+        "axios-mock-adapter": "^1.20.0",
         "csstype": "^2.6.2",
         "eslint": "^7.32.0",
         "eslint-plugin-react": "^7.26.1",
@@ -1051,6 +1051,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
       "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "is-blob": "^2.1.0",
@@ -2227,7 +2228,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -2692,6 +2694,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
       "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -2719,6 +2722,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5855,6 +5859,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
       "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "is-blob": "^2.1.0",
@@ -6711,7 +6716,8 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -7048,7 +7054,8 @@
     "is-blob": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
-      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw=="
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true
     },
     "is-boolean-object": {
       "version": "1.1.2",
@@ -7063,7 +7070,8 @@
     "is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@szhsin/react-menu": "^2.3.1",
     "apexcharts": "^3.31.0",
     "axios": "^0.24.0",
-    "axios-mock-adapter": "^1.20.0",
     "classnames": "^2.3.1",
     "dayjs": "^1.10.7",
     "i18next": "^21.6.12",
@@ -66,6 +65,7 @@
   "devDependencies": {
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "autoprefixer": "^10.3.3",
+    "axios-mock-adapter": "^1.20.0",
     "csstype": "^2.6.2",
     "eslint": "^7.32.0",
     "eslint-plugin-react": "^7.26.1",


### PR DESCRIPTION
One of my IT mates told me, that :
 "axios-mock-adapter" and "@reduxjs/toolkit" should be in Dev Dependencies and it makes sense.

Regards,