### PR TITLE
Align notice cards to the container top start

### DIFF
--- a/src/views/notices/Notice_CardsWrapper/Notice_CardsWrapper.jsx
+++ b/src/views/notices/Notice_CardsWrapper/Notice_CardsWrapper.jsx
@@ -1,12 +1,12 @@
 
-const NoticeCardsWrapper = ({icon: Icon, title="Notice Card Title", hashId, children}) => (
+const NoticeCardsWrapper = ({ icon: Icon, title = "Notice Card Title", hashId, children }) => (
 
   <div id={hashId} className="bg-white p-8 pb-20 mb-36 rounded-xl shadow-xl scroll-mt-16">
     <h2 className="flex flex-wrap justify-center items-center gap-x-4 gap-y-4 text-center text-3xl sm:text-4xl font-bold mb-12 mt-8">
-      <Icon className={'text-primary min-h-[65px] min-w-[65px] sm:min-h-[90px] sm:min-w-[90px]'}/>
+      <Icon className={'text-primary min-h-[65px] min-w-[65px] sm:min-h-[90px] sm:min-w-[90px]'} />
       {title}
     </h2>
-    <div className="flex flex-wrap lg:flex-nowrap justify-center gap-y-12 gap-x-16">
+    <div className="flex items-start flex-wrap lg:flex-nowrap justify-center gap-y-12 gap-x-16">
       {children}
     </div>
   </div>


### PR DESCRIPTION
As reported by a Discord Team member:

![image](https://user-images.githubusercontent.com/101098165/157550377-c3f2cbd0-1423-4941-98bb-f8654fafe1ed.png)

Fix implemented by adding 'items-start` class.

Results:
![image](https://user-images.githubusercontent.com/101098165/157550987-49d1a0b8-7045-4b82-9711-8b8b54d03a44.png)

