### PR TITLE
Support SMS token in notices edit route

### DIFF
--- a/src/app/router/urls/notices/notices.js
+++ b/src/app/router/urls/notices/notices.js
@@ -41,7 +41,7 @@ export const noticesRoutes = {
   'notices.addOfferWork': `${BASE_URL}/dodaj-ogloszenie/offer-work`,
   'notices.addFindWork': `${BASE_URL}/dodaj-ogloszenie/find-work`,
   'notices.success': `${BASE_URL}/dodaj-ogloszenie/sukces`,
-  'notices.edit': (id = ':id', token = ':token') => `${BASE_URL}/e/${id}/${token}`,
+  'notices.edit': (id = ':id', token = ':token', smsToken = ':smsToken') => `${BASE_URL}/e/${id}/${token}/${smsToken}`,
   'notices.edit2': (id = ':id', token = ':token', pin = ':pin') =>
     `${BASE_URL}/e/${id}/${token}/${pin}`,
 }


### PR DESCRIPTION
https://trello.com/c/zs9DiKqF/172-include-sms-token-parameter-in-notices-edit-route

I don't know how to add a notice without a verification and I was unable to verify this fix on my local env.

If you are 100% sure that my fix looks good and will work fine - feel free to approve and merge it.
But also please let me know how can I add a Notice and Edit it without verifications so I can verify the fix locally.

Thanks.

Regards.